### PR TITLE
feat(metro): support csv assets

### DIFF
--- a/twins/twins-native/metro.config.js
+++ b/twins/twins-native/metro.config.js
@@ -1,0 +1,7 @@
+const { getDefaultConfig } = require('expo/metro-config');
+
+const config = getDefaultConfig(__dirname);
+
+config.resolver.assetExts.push('csv');
+
+module.exports = config;


### PR DESCRIPTION
## Summary
- add metro config and include csv in asset extensions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx expo lint` *(fails: 403 Forbidden - GET https://registry.npmjs.org/expo)*
- `npm run start` *(fails: expo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae78b9833c8325af395695dff0efb1