### PR TITLE
feat(metro): support csv assets

### DIFF
--- a/twins/twins-native/app/results.tsx
+++ b/twins/twins-native/app/results.tsx
@@ -111,7 +111,7 @@ const styles = StyleSheet.create({
     marginBottom: DesignSystem.spacing[4],
   },
   loadingText: {
-    fontFamily: 'Inter',
+    fontFamily: DesignSystem.typography.fontFamilyBase,
     fontSize: DesignSystem.typography.fontSizeMd,
     color: DesignSystem.colors.textMuted,
     marginBottom: DesignSystem.spacing[4],

--- a/twins/twins-native/components/ThemedText.tsx
+++ b/twins/twins-native/components/ThemedText.tsx
@@ -37,32 +37,32 @@ export function ThemedText({
 
 const styles = StyleSheet.create({
   default: {
-    fontFamily: 'Inter',
+    fontFamily: DesignSystem.typography.fontFamilyBase,
     fontSize: DesignSystem.typography.fontSizeMd,
     lineHeight:
       DesignSystem.typography.fontSizeMd * DesignSystem.typography.lineHeightBase,
   },
   defaultSemiBold: {
-    fontFamily: 'Inter',
+    fontFamily: DesignSystem.typography.fontFamilyBase,
     fontWeight: '600',
     fontSize: DesignSystem.typography.fontSizeMd,
     lineHeight:
       DesignSystem.typography.fontSizeMd * DesignSystem.typography.lineHeightBase,
   },
   title: {
-    fontFamily: 'Inter',
+    fontFamily: DesignSystem.typography.fontFamilyBase,
     fontWeight: '700',
     fontSize: DesignSystem.typography.fontSizeXl,
     lineHeight:
       DesignSystem.typography.fontSizeXl * DesignSystem.typography.lineHeightBase,
   },
   subtitle: {
-    fontFamily: 'Inter',
+    fontFamily: DesignSystem.typography.fontFamilyBase,
     fontWeight: '700',
     fontSize: DesignSystem.typography.fontSizeLg,
   },
   link: {
-    fontFamily: 'Inter',
+    fontFamily: DesignSystem.typography.fontFamilyBase,
     lineHeight:
       DesignSystem.typography.fontSizeMd * DesignSystem.typography.lineHeightBase,
     fontSize: DesignSystem.typography.fontSizeMd,

--- a/twins/twins-native/constants/DesignSystem.ts
+++ b/twins/twins-native/constants/DesignSystem.ts
@@ -13,9 +13,9 @@ export const DesignSystem = {
     danger: '#E53E3E',
   },
   typography: {
-    fontFamily:
+    fontFamilyBase:
       'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
-    monospace: 'Roboto Mono, Fira Code, monospace',
+    fontFamilyMono: 'Roboto Mono, Fira Code, monospace',
     fontSizeXs: 12,
     fontSizeSm: 14,
     fontSizeMd: 16,

--- a/twins/twins-native/metro.config.js
+++ b/twins/twins-native/metro.config.js
@@ -1,0 +1,7 @@
+const { getDefaultConfig } = require('expo/metro-config');
+
+const config = getDefaultConfig(__dirname);
+
+config.resolver.assetExts.push('csv');
+
+module.exports = config;


### PR DESCRIPTION
## Summary
- add metro config and include csv in asset extensions
- switch font styles to design token constants

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx expo lint` *(fails: 403 Forbidden - GET https://registry.npmjs.org/expo)*
- `npm run start` *(fails: expo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae78b9833c8325af395695dff0efb1