### PR TITLE
feat: use likert scale for questionnaire

### DIFF
--- a/twins/twins-native/app/questionnaire.tsx
+++ b/twins/twins-native/app/questionnaire.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { ScrollView, Button, TextInput, StyleSheet, View } from 'react-native';
+import { ScrollView, Button, StyleSheet, View, TouchableOpacity } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { parseQuestionList, Question } from '@/utils/csvParser';
 import { ThemedText } from '@/components/ThemedText';
@@ -41,13 +41,22 @@ export default function QuestionnaireScreen() {
   return (
     <ScrollView contentContainerStyle={styles.container}>
       {questions.map((q) => (
-        <View key={q.number} style={styles.question}>
-          <ThemedText>{q.text}</ThemedText>
-          <TextInput
-            style={styles.input}
-            placeholder="Enter your answer"
-            onChangeText={(text) => handleAnswer(Number(q.number), text)}
-          />
+        <View key={q.itemNumber} style={styles.question}>
+          <ThemedText>{q.question}</ThemedText>
+          <View style={styles.optionsContainer}>
+            {[1, 2, 3, 4, 5].map((value) => (
+              <TouchableOpacity
+                key={value}
+                style={[
+                  styles.option,
+                  answers[Number(q.itemNumber)] === String(value) && styles.selectedOption,
+                ]}
+                onPress={() => handleAnswer(Number(q.itemNumber), String(value))}
+              >
+                <ThemedText>{value}</ThemedText>
+              </TouchableOpacity>
+            ))}
+          </View>
         </View>
       ))}
       <Button
@@ -67,11 +76,20 @@ const styles = StyleSheet.create({
   question: {
     marginBottom: DesignSystem.spacing[4],
   },
-  input: {
+  optionsContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: DesignSystem.spacing[2],
+  },
+  option: {
     borderWidth: 1,
     borderColor: DesignSystem.colors.border,
     borderRadius: DesignSystem.radius.sm,
     padding: DesignSystem.spacing[2],
-    marginTop: DesignSystem.spacing[2],
+    minWidth: 40,
+    alignItems: 'center',
+  },
+  selectedOption: {
+    backgroundColor: DesignSystem.colors.primary,
   },
 });

--- a/twins/twins-native/assets/questionList.csv
+++ b/twins/twins-native/assets/questionList.csv
@@ -1,4 +1,4 @@
-Question_Number,Question_Text,Scale,Direction,Scale_Name
+Item_Number,Question,Scale,Direction,Factor_Name
 1,"Am the life of the party.",1,+,Extraversion
 2,"Feel little concern for others.",2,-,Agreeableness
 3,"Am always prepared.",3,+,Conscientiousness

--- a/twins/twins-native/types.tsx
+++ b/twins/twins-native/types.tsx
@@ -12,8 +12,8 @@ export enum Screen {
     gender: string;
   }
   
-  export type AnswerType = 'Like Scale' | 'YES/NO';
-  
+  export type AnswerType = 'Likert';
+
   export interface Question {
     category: string;
     question: string;

--- a/twins/twins-native/utils/csvParser.ts
+++ b/twins/twins-native/utils/csvParser.ts
@@ -2,11 +2,11 @@ import { Asset } from 'expo-asset';
 import * as FileSystem from 'expo-file-system';
 
 export interface Question {
-  number: string;
-  text: string;
+  itemNumber: string;
+  question: string;
   scale: string;
   direction: string;
-  scaleName: string;
+  factorName: string;
 }
 
 export async function parseQuestionList(): Promise<Question[]> {
@@ -18,7 +18,7 @@ export async function parseQuestionList(): Promise<Question[]> {
     .split('\n')
     .slice(1)
     .map((line) => {
-      const [number, text, scale, direction, scaleName] = line.split(',');
-      return { number, text, scale, direction, scaleName };
+      const [itemNumber, question, scale, direction, factorName] = line.split(',');
+      return { itemNumber, question, scale, direction, factorName };
     });
 }


### PR DESCRIPTION
## Summary
- present Big Five question list in new Item_Number/Question format
- parse updated CSV structure and expose item number and factor name
- capture questionnaire answers via 1-5 Likert options and restrict AnswerType to `Likert`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: expo: not found)
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/d3)


------
https://chatgpt.com/codex/tasks/task_e_68ae7f34bc8083259fb1e4750f1d740b