### PR TITLE
Improve registration validation and questionnaire navigation

### DIFF
--- a/twins/twins-native/app/index.tsx
+++ b/twins/twins-native/app/index.tsx
@@ -1,5 +1,11 @@
 import React, { useState } from 'react';
-import { TextInput, Button, StyleSheet } from 'react-native';
+import {
+  TextInput,
+  Button,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { useRouter } from 'expo-router';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
@@ -12,6 +18,9 @@ const RegistrationScreen: React.FC = () => {
   const [email, setEmail] = useState('');
   const [ageRange, setAgeRange] = useState('');
   const [gender, setGender] = useState('');
+  const [showAgeDropdown, setShowAgeDropdown] = useState(false);
+  const [showGenderDropdown, setShowGenderDropdown] = useState(false);
+  const [errors, setErrors] = useState<{ nickname?: string; email?: string; ageRange?: string; gender?: string }>({});
   const router = useRouter();
 
   const backgroundColor = useThemeColor({}, 'background');
@@ -19,8 +28,18 @@ const RegistrationScreen: React.FC = () => {
   const borderColor = useThemeColor({}, 'border');
   const textColor = useThemeColor({}, 'text');
 
+  const ageOptions = ['<18', '18-24', '25-34', '35-44', '45+'];
+  const genderOptions = ['M', 'F', 'Non-Binary', 'Prefer Not To Say'];
+
   const handleRegister = () => {
-    if (nickname && email && ageRange && gender) {
+    const newErrors: { nickname?: string; email?: string; ageRange?: string; gender?: string } = {};
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (nickname.length <= 3) newErrors.nickname = 'Nickname must be longer than 3 characters';
+    if (!emailRegex.test(email)) newErrors.email = 'Invalid email address';
+    if (!ageRange) newErrors.ageRange = 'Age group is required';
+    if (!gender) newErrors.gender = 'Gender is required';
+    setErrors(newErrors);
+    if (Object.keys(newErrors).length === 0) {
       const user: User = { nickname, email, ageRange, gender };
       router.push({ pathname: '/questionnaire', params: { user: JSON.stringify(user) } });
     }
@@ -38,6 +57,7 @@ const RegistrationScreen: React.FC = () => {
         onChangeText={setNickname}
         placeholderTextColor={textColor}
       />
+      {errors.nickname && <ThemedText style={styles.errorText}>{errors.nickname}</ThemedText>}
       <TextInput
         style={[styles.input, { borderColor, color: textColor }]}
         placeholder="Email"
@@ -46,20 +66,57 @@ const RegistrationScreen: React.FC = () => {
         keyboardType="email-address"
         placeholderTextColor={textColor}
       />
-      <TextInput
-        style={[styles.input, { borderColor, color: textColor }]}
-        placeholder="Age Range"
-        value={ageRange}
-        onChangeText={setAgeRange}
-        placeholderTextColor={textColor}
-      />
-      <TextInput
-        style={[styles.input, { borderColor, color: textColor }]}
-        placeholder="Gender"
-        value={gender}
-        onChangeText={setGender}
-        placeholderTextColor={textColor}
-      />
+      {errors.email && <ThemedText style={styles.errorText}>{errors.email}</ThemedText>}
+      <TouchableOpacity
+        style={[styles.input, { borderColor }]}
+        onPress={() => setShowAgeDropdown(!showAgeDropdown)}
+      >
+        <ThemedText style={{ color: ageRange ? textColor : DesignSystem.colors.textMuted }}>
+          {ageRange || 'Select Age Group'}
+        </ThemedText>
+      </TouchableOpacity>
+      {showAgeDropdown && (
+        <View style={[styles.dropdown, { borderColor, backgroundColor }]}>
+          {ageOptions.map((option) => (
+            <TouchableOpacity
+              key={option}
+              style={styles.dropdownOption}
+              onPress={() => {
+                setAgeRange(option);
+                setShowAgeDropdown(false);
+              }}
+            >
+              <ThemedText style={{ color: textColor }}>{option}</ThemedText>
+            </TouchableOpacity>
+          ))}
+        </View>
+      )}
+      {errors.ageRange && <ThemedText style={styles.errorText}>{errors.ageRange}</ThemedText>}
+      <TouchableOpacity
+        style={[styles.input, { borderColor }]}
+        onPress={() => setShowGenderDropdown(!showGenderDropdown)}
+      >
+        <ThemedText style={{ color: gender ? textColor : DesignSystem.colors.textMuted }}>
+          {gender || 'Select Gender'}
+        </ThemedText>
+      </TouchableOpacity>
+      {showGenderDropdown && (
+        <View style={[styles.dropdown, { borderColor, backgroundColor }]}>
+          {genderOptions.map((option) => (
+            <TouchableOpacity
+              key={option}
+              style={styles.dropdownOption}
+              onPress={() => {
+                setGender(option);
+                setShowGenderDropdown(false);
+              }}
+            >
+              <ThemedText style={{ color: textColor }}>{option}</ThemedText>
+            </TouchableOpacity>
+          ))}
+        </View>
+      )}
+      {errors.gender && <ThemedText style={styles.errorText}>{errors.gender}</ThemedText>}
       <Button
         title="Register"
         onPress={handleRegister}
@@ -84,7 +141,21 @@ const styles = StyleSheet.create({
     padding: DesignSystem.spacing[2],
     borderWidth: 1,
     marginBottom: DesignSystem.spacing[4],
-    borderRadius: DesignSystem.radius.sm,
+    borderRadius: DesignSystem.radius.lg,
+  },
+  dropdown: {
+    width: '100%',
+    borderWidth: 1,
+    borderRadius: DesignSystem.radius.lg,
+    marginBottom: DesignSystem.spacing[4],
+  },
+  dropdownOption: {
+    padding: DesignSystem.spacing[2],
+  },
+  errorText: {
+    color: DesignSystem.colors.danger,
+    marginBottom: DesignSystem.spacing[2],
+    alignSelf: 'flex-start',
   },
 });
 

--- a/twins/twins-native/app/questionnaire.tsx
+++ b/twins/twins-native/app/questionnaire.tsx
@@ -16,6 +16,7 @@ export default function QuestionnaireScreen() {
   const backgroundColor = useThemeColor({}, 'background');
   const primaryColor = useThemeColor({}, 'primary');
   const borderColor = useThemeColor({}, 'border');
+  const textColor = useThemeColor({}, 'text');
 
   useEffect(() => {
     async function loadQuestions() {
@@ -37,34 +38,43 @@ export default function QuestionnaireScreen() {
     router.push({
       pathname: '/results',
       params: {
-        user: userParam as string,
-        answers: JSON.stringify(answersArray),
+        user: encodeURIComponent(userParam as string),
+        answers: encodeURIComponent(JSON.stringify(answersArray)),
       },
     });
   };
 
   return (
     <ScrollView contentContainerStyle={[styles.container, { backgroundColor }]}>
-      {questions.map((q) => (
-        <View key={q.itemNumber} style={styles.question}>
-          <ThemedText>{q.question}</ThemedText>
-          <View style={styles.optionsContainer}>
-            {[1, 2, 3, 4, 5].map((value) => (
-              <TouchableOpacity
-                key={value}
-                style={[
-                  styles.option,
-                  { borderColor },
-                  answers[Number(q.itemNumber)] === String(value) && [styles.selectedOption, { backgroundColor: primaryColor }],
-                ]}
-                onPress={() => handleAnswer(Number(q.itemNumber), String(value))}
-              >
-                <ThemedText>{value}</ThemedText>
-              </TouchableOpacity>
-            ))}
+      {questions.map((q) => {
+        const questionText = q.question.replace(/^"|"$/g, '');
+        const formattedQuestion = `I ${questionText.charAt(0).toLowerCase()}${questionText.slice(1)}`;
+        return (
+          <View key={q.itemNumber} style={styles.question}>
+            <ThemedText>{formattedQuestion}</ThemedText>
+            <View style={styles.optionsContainer}>
+              {[1, 2, 3, 4, 5].map((value) => {
+                const selected = answers[Number(q.itemNumber)] === String(value);
+                return (
+                  <TouchableOpacity
+                    key={value}
+                    style={[
+                      styles.option,
+                      { borderColor },
+                      selected && [styles.selectedOption, { backgroundColor: primaryColor }],
+                    ]}
+                    onPress={() => handleAnswer(Number(q.itemNumber), String(value))}
+                  >
+                    <ThemedText style={selected ? styles.selectedText : { color: textColor }}>
+                      {value}
+                    </ThemedText>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
           </View>
-        </View>
-      ))}
+        );
+      })}
       <Button
         title="Submit"
         onPress={handleSubmit}
@@ -94,4 +104,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   selectedOption: {},
+  selectedText: {
+    color: DesignSystem.colors.bg,
+  },
 });

--- a/twins/twins-native/app/results.tsx
+++ b/twins/twins-native/app/results.tsx
@@ -14,8 +14,12 @@ const traits = ['Openness', 'Conscientiousness', 'Extraversion', 'Agreeableness'
 function ResultsScreen() {
   const { answers: answersParam, user: userParam } = useLocalSearchParams();
   const router = useRouter();
-  const answers: Answer[] = answersParam ? JSON.parse(answersParam as string) : [];
-  const user = userParam ? JSON.parse(userParam as string) : { nickname: '' };
+  const answers: Answer[] = answersParam
+    ? JSON.parse(decodeURIComponent(answersParam as string))
+    : [];
+  const user = userParam
+    ? JSON.parse(decodeURIComponent(userParam as string))
+    : { nickname: '' };
   const [profileData, setProfileData] = useState<number[] | null>(null);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Implement rounded registration form with dropdowns for age group and gender plus email and nickname validation.
- Format questionnaire prompts as sentences starting with "I" and highlight selected answers with contrasting text.
- Encode questionnaire submission parameters and decode in results to fix broken navigation.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: expo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae837c875c8325ba08d5201562b423